### PR TITLE
Fix utils.runcmd for colab

### DIFF
--- a/CUDA_code/utils.py
+++ b/CUDA_code/utils.py
@@ -222,6 +222,11 @@ def runcmd(command):
     t = None        # `t` will be the progress bar object
     prev_pv = -1    # `prev_pv` will contain previous iteration's progress bar value (pv)
     
+    # Split command as a list of strings if it is a single string
+    # For e.g, this is needed for Popen() to work on Colab
+    if type(command) == str:
+        command = command.split(" ")
+    
     # Run the command as a subprocess
     process = Popen(command, stdout=PIPE, shell=False, stderr=STDOUT, bufsize=1, close_fds=True, universal_newlines=True)
     


### PR DESCRIPTION
Fixes the following issues:
1 - Colab expects `subprocess.Popen()` to be a list of string
2 - Jupyter on Colab displays the following warning when console output exceeds its default `iopub_data_rate_limit`
```
IOPub data rate exceeded.
The notebook server will temporarily stop sending output
to the client in order to avoid crashing it.
To change this limit, set the config variable
`--NotebookApp.iopub_data_rate_limit`.
```
Current default Colab config

```
iopub_data_rate_limit=1mb/s
rate_limit_window=3seconds
```

Addressed the issue by rate-limiting how often we update the progress bar (default to once every one second, configurable using the `update_interval` optional argument).

For e.g

```python
# the progress bar updates every 1 second
utils.runcmd(f'./file {params} {handle}')

# or updates the progress bar every 2 second
utils.runcmd(f'./file {params} {handle}', update_interval=2)

```

We still can hit the `iopub_data_rate_limit` if the scripts prints out too fast to the console; this fix just mitigates the ones caused by the progress bar.

It's possible to use `time.sleep(1)` manually to slow down printing to the console, for e.g

```python

import time

for x in runs:
	# setup params and handle
	utils.runcmd(f'./file {params} {handle}')

	# a delay in between runs to avoid hitting the NotebookApp.iopub_data_rate_limit
	time.sleep(3) 

```